### PR TITLE
Fix a quick typo in spec description

### DIFF
--- a/spec/lib/fingerprint_parser_spec.rb
+++ b/spec/lib/fingerprint_parser_spec.rb
@@ -10,7 +10,7 @@ describe FingerprintParser do
       end
     end
 
-    context 'with on element' do
+    context 'with one element' do
       it 'returns the element' do
         subject.extract_fingerprint('meh').should == 'meh'
       end


### PR DESCRIPTION
It's a small thing I know but once I saw it I couldn't "un-see" it :-)
