### PR TITLE
Keep track of short URL usage

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,7 @@ group :test do
   gem 'minitest-reporters'
   gem 'capybara'
   gem 'launchy'
+  gem 'mocha'
 
   gem 'guard'
   gem 'guard-minitest'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,6 +88,7 @@ GEM
     lumberjack (1.0.10)
     mail (2.6.4)
       mime-types (>= 1.16, < 4)
+    metaclass (0.0.4)
     method_source (0.8.2)
     mime-types (3.0)
       mime-types-data (~> 3.2015)
@@ -99,6 +100,8 @@ GEM
       builder
       minitest (>= 5.0)
       ruby-progressbar
+    mocha (1.1.0)
+      metaclass (~> 0.0.1)
     nenv (0.3.0)
     nokogiri (1.6.7.2)
       mini_portile2 (~> 2.0.0.rc2)
@@ -155,6 +158,7 @@ DEPENDENCIES
   launchy
   minitest
   minitest-reporters
+  mocha
   rake
   sass
   sqlite3

--- a/apps/admin/assets/stylesheets/application.css.scss
+++ b/apps/admin/assets/stylesheets/application.css.scss
@@ -48,11 +48,19 @@ body {
             text-decoration: underline;
         }
 
-        .actions {
+        ul.meta {
             text-align: right;
 
-            a {
+            li.statistics,
+            li.actions {
+                list-style: none;
+                display: inline-block;
+                margin-left: 0.8em;
                 color: $mediumgray-light;
+
+                a {
+                    color: $mediumgray-light;
+                }
             }
         }
     }

--- a/apps/admin/templates/dashboard/index.html.haml
+++ b/apps/admin/templates/dashboard/index.html.haml
@@ -16,9 +16,10 @@
             .col-xs-8
               .short= link_to item.short_url, item.short_url
             .col-xs-4
-              .statistics
-                %i.fa.fa-line-chart.fa-lg
-                = item.number_of_clicks
-              .actions
-                = delete_link(item)
+              %ul.meta
+                %li.statistics
+                  %i.fa.fa-line-chart.fa-lg
+                  = item.number_of_clicks
+                %li.actions
+                  = delete_link(item)
 

--- a/apps/admin/templates/dashboard/index.html.haml
+++ b/apps/admin/templates/dashboard/index.html.haml
@@ -16,6 +16,9 @@
             .col-xs-8
               .short= link_to item.short_url, item.short_url
             .col-xs-4
+              .statistics
+                %i.fa.fa-line-chart.fa-lg
+                = item.number_of_clicks
               .actions
                 = delete_link(item)
 

--- a/apps/web/application.rb
+++ b/apps/web/application.rb
@@ -1,5 +1,6 @@
 require 'hanami/helpers'
 require 'hanami/assets'
+require 'hanami/action/cache'
 
 module Web
   class Application < Hanami::Application
@@ -211,8 +212,7 @@ module Web
       #
       # See: http://www.rubydoc.info/gems/hanami-controller#Configuration
       controller.prepare do
-        # include MyAuthentication # included in all the actions
-        # before :authenticate!    # run an authentication before callback
+        include Hanami::Action::Cache
       end
 
       # Configure the code that will yield each time Web::View is included

--- a/apps/web/controllers/items/resolver.rb
+++ b/apps/web/controllers/items/resolver.rb
@@ -2,10 +2,9 @@ module Web::Controllers::Items
   class Resolver
     include Web::Action
 
-    # TODO: Add http cache
-
     def call(params)
       @item = ItemRepository.find_by_code(params[:code])
+      result = ClickRepository.register_for(@item)
       redirect_to @item.content, status: 301
     end
   end

--- a/apps/web/controllers/items/resolver.rb
+++ b/apps/web/controllers/items/resolver.rb
@@ -2,6 +2,8 @@ module Web::Controllers::Items
   class Resolver
     include Web::Action
 
+    cache_control :private, max_age: 90
+
     def call(params)
       @item = ItemRepository.find_by_code(params[:code])
       result = ClickRepository.register_for(@item)

--- a/db/migrations/20160403192945_create_clicks.rb
+++ b/db/migrations/20160403192945_create_clicks.rb
@@ -1,0 +1,9 @@
+Hanami::Model.migration do
+  change do
+    create_table :clicks do
+      primary_key :id
+      column :item_id,      Integer,    null: false
+      column :created_at,   DateTime,   null: false
+    end
+  end
+end

--- a/lib/firefly.rb
+++ b/lib/firefly.rb
@@ -46,6 +46,15 @@ Hanami::Model.configure do
       attribute :created_at, DateTime
       attribute :updated_at, DateTime
     end
+
+    collection :clicks do
+      entity Click
+      repository ClickRepository
+
+      attribute :id,         Integer
+      attribute :item_id,    Integer
+      attribute :created_at, DateTime
+    end
   end
 end.load!
 

--- a/lib/firefly/entities/click.rb
+++ b/lib/firefly/entities/click.rb
@@ -1,0 +1,4 @@
+class Click
+  include Hanami::Entity
+  attributes :item_id, :created_at
+end

--- a/lib/firefly/entities/item.rb
+++ b/lib/firefly/entities/item.rb
@@ -10,6 +10,14 @@ class Item
     Base62.encode(id)
   end
 
+  def click!
+    ClickRepository.register_for(self)
+  end
+
+  def number_of_clicks
+    ClickRepository.clicks_for(self)
+  end
+
   private
 
   def protocol

--- a/lib/firefly/repositories/click_repository.rb
+++ b/lib/firefly/repositories/click_repository.rb
@@ -1,0 +1,3 @@
+class ClickRepository
+  include Hanami::Repository
+end

--- a/lib/firefly/repositories/click_repository.rb
+++ b/lib/firefly/repositories/click_repository.rb
@@ -1,3 +1,17 @@
 class ClickRepository
   include Hanami::Repository
+
+  def self.clicks_for(item)
+    query  do
+      where(item_id: item.id)
+    end.count
+  end
+
+  def self.register_for(item, count = 1)
+    transaction do
+      count.times do
+        create(Click.new(item_id: item.id))
+      end
+    end
+  end
 end

--- a/spec/admin/features/dashboard_spec.rb
+++ b/spec/admin/features/dashboard_spec.rb
@@ -60,6 +60,17 @@ describe 'dashboard' do
     assert page.has_text?("Please enter a valid URL")
   end
 
+  it 'shows item statistics' do
+    @item = @items[3]
+    3.times { ClickRepository.create(Click.new(item_id: @item.id)) }
+
+    basic_auth('admin', 'password')
+    visit '/admin'
+
+    within("#item_#{@item.id} .statistics") do
+      assert page.has_text?("3")
+    end
+  end
 
   describe 'deletion of an item' do
     before do

--- a/spec/admin/features/dashboard_spec.rb
+++ b/spec/admin/features/dashboard_spec.rb
@@ -62,7 +62,7 @@ describe 'dashboard' do
 
   it 'shows item statistics' do
     @item = @items[3]
-    3.times { ClickRepository.create(Click.new(item_id: @item.id)) }
+    ClickRepository.register_for(@item, 3)
 
     basic_auth('admin', 'password')
     visit '/admin'

--- a/spec/firefly/entities/click_spec.rb
+++ b/spec/firefly/entities/click_spec.rb
@@ -1,0 +1,4 @@
+require 'spec_helper'
+
+describe Click do
+end

--- a/spec/firefly/entities/item_spec.rb
+++ b/spec/firefly/entities/item_spec.rb
@@ -5,8 +5,10 @@ describe Item do
   before do
     ItemRepository.clear
 
-    @item = ItemRepository.create(Item.new(type: 'url', content: 'http://nu.nl'))
-    @code = Base62.encode(@item.id)
+    @item  = ItemRepository.create(Item.new(type: 'url', content: 'http://nu.nl'))
+    @code  = Base62.encode(@item.id)
+
+    ClickRepository.register_for(@item, 3)
   end
 
   it '#short_url' do
@@ -23,4 +25,13 @@ describe Item do
     @item.code.must_equal(@code)
   end
 
+  it '#number_of_clicks' do
+    assert_equal 3, @item.number_of_clicks
+  end
+
+  it '#click!' do
+    assert_equal 3, @item.number_of_clicks
+    @item.click!
+    assert_equal 4, @item.number_of_clicks
+  end
 end

--- a/spec/firefly/repositories/click_repository_spec.rb
+++ b/spec/firefly/repositories/click_repository_spec.rb
@@ -1,0 +1,4 @@
+require 'spec_helper'
+
+describe ClickRepository do
+end

--- a/spec/firefly/repositories/click_repository_spec.rb
+++ b/spec/firefly/repositories/click_repository_spec.rb
@@ -1,4 +1,22 @@
 require 'spec_helper'
 
 describe ClickRepository do
+  before do
+    ItemRepository.clear
+    ClickRepository.clear
+
+    @item = ItemRepository.create(Item.new(type: 'url', content: "https://devroom.io/page"))
+  end
+
+  it 'records single clicks' do
+    assert_equal 0, ClickRepository.clicks_for(@item)
+    ClickRepository.register_for(@item)
+    assert_equal 1, ClickRepository.clicks_for(@item)
+  end
+
+  it 'records multiple clicks' do
+    assert_equal 0, ClickRepository.clicks_for(@item)
+    ClickRepository.register_for(@item, 3)
+    assert_equal 3, ClickRepository.clicks_for(@item)
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,6 +17,8 @@ require 'minitest/autorun'
 require 'minitest/reporters'
 require 'byebug'
 
+require 'mocha/mini_test'
+
 Minitest::Reporters.use!
 
 Hanami::Application.preload!

--- a/spec/web/controllers/items/resolver_spec.rb
+++ b/spec/web/controllers/items/resolver_spec.rb
@@ -15,4 +15,9 @@ describe Web::Controllers::Items::Resolver do
     response[0].must_equal 301
     response[1]['Location'].must_equal 'https://devroom.io'
   end
+
+  it 'records as a click' do
+    ClickRepository.expects(:register_for).with(@item).once
+    action.call(Hash[code: @code])
+  end
 end

--- a/spec/web/controllers/items/resolver_spec.rb
+++ b/spec/web/controllers/items/resolver_spec.rb
@@ -16,6 +16,11 @@ describe Web::Controllers::Items::Resolver do
     response[1]['Location'].must_equal 'https://devroom.io'
   end
 
+  it 'has correct Cache-Control headers' do
+    response = action.call(Hash[code: @code])
+    response[1]['Cache-Control'].must_equal 'private, max-age=90'
+  end
+
   it 'records as a click' do
     ClickRepository.expects(:register_for).with(@item).once
     action.call(Hash[code: @code])


### PR DESCRIPTION
To analyse traffic, we should keep track of when and which short URLs are served. Minimally we'd need:

 * Item served
 * Timestamp

For now display the total number of hits on an item, but we might go further and draw a nice graph in the future.