### PR TITLE
Auto-focus on content field in admin

### DIFF
--- a/apps/admin/views/dashboard/index.rb
+++ b/apps/admin/views/dashboard/index.rb
@@ -28,7 +28,7 @@ module Admin::Views::Dashboard
     def form
       form_for :item, '/admin/items' do
         div class: 'input-group input-group-lg' do
-          text_field :content, class: 'form-control', placeholder: 'What can I shorten for you today?'
+          text_field :content, class: 'form-control', placeholder: 'What can I shorten for you today?', autofocus: true
           span class: 'input-group-btn' do
             submit 'Shorten', class: 'btn btn-search', :"data-disable-with" => "Shortening..."
           end


### PR DESCRIPTION
> _This is a beginner friendly issue_ which means that it should be a nice first task if you're looking to learn Ruby or Hanami. Feel free to ask questions in the comments or hop over to [gitter](https://gitter.im/ariejan/firefly) to chat with the maintainer and others. And remember to have fun!

When entering the /admin page, auto-focus on the content field, so the user can directly paste the URL to shorten. 